### PR TITLE
feat: Add initial TravisCI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: rust
+os:
+  - linux
+  - windows
 rust:
   - stable
   - beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+# Cache dependencies so that they are only recompiled
+# if they or the compiler were upgraded
+cache: cargo
+before_script:
+  - rustup component add clippy-preview
+script:
+  - cargo clippy --all-targets --all-features -- -D warnings
+  - cargo test --verbose
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ rust:
   - stable
   - beta
   - nightly
-# Cache dependencies so that they are only recompiled
-# if they or the compiler were upgraded
-cache: cargo
+# Need to cache the whole `.cargo` directory to keep .crates.toml for
+# cargo-update to work, but don't cache the cargo registry
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
+cache:
+  directories:
+    - /home/travis/.cargo
 before_script:
   - rustup component add clippy-preview
 script:

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ supernova
 .. image:: https://travis-ci.org/0xazure/supernova.svg?branch=master
     :target: https://travis-ci.org/0xazure/supernova
 
-A tool for exporting GitHub stars as an organized list.
+    Tool for exporting GitHub stars as an organized list.
 
 things learned
 --------------

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
 supernova
 =========
 
-  Tool for exporting GitHub stars as an organized list.
+.. image:: https://travis-ci.org/0xazure/supernova.svg?branch=master
+    :target: https://travis-ci.org/0xazure/supernova
+
+A tool for exporting GitHub stars as an organized list.
 
 things learned
 --------------

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@ supernova
 .. image:: https://travis-ci.org/0xazure/supernova.svg?branch=master
     :target: https://travis-ci.org/0xazure/supernova
 
+|
+
     Tool for exporting GitHub stars as an organized list.
 
 things learned


### PR DESCRIPTION
Fixes #3: Integrate TravisCI for fast feedback cycles

This initial Travis configuration supports stable, beta, and nightly versions of Rust with failures allowed for nightly.

In addition, it also supports caching Cargo dependencies, as well as linting and tests.