### PR TITLE
refactor: prefer `use` to bring macros into scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-#[macro_use]
-extern crate serde_derive;
 extern crate chrono;
 extern crate reqwest;
+extern crate serde_derive;
 extern crate serde_json;
 
 use chrono::{DateTime, Utc};
 use reqwest::header::{qitem, Accept, Authorization, Bearer, Link, RelationType, UserAgent};
+use serde_derive::Deserialize;
 use std::{env, error, fmt, mem};
 
 #[derive(Debug)]


### PR DESCRIPTION
As of Rust 1.30, we can remove the need for `macro_use` annotations and instead `use` macros defined in external crates to bring them into scope.

See: https://blog.rust-lang.org/2018/10/25/Rust-1.30.0.html#use-and-macros