### PR TITLE
bug: Do not run clippy on beta toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ cache:
   directories:
     - /home/travis/.cargo
 before_script:
-  - rustup component add clippy-preview
+  - if [[ "$TRAVIS_RUST_VERSION" == "stable" || "$TRAVIS_RUST_VERSION" == "nightly" ]]; then rustup component add clippy-preview; fi
 script:
-  - cargo clippy --all-targets --all-features -- -D warnings
+  - if [[ "$TRAVIS_RUST_VERSION" == "stable" || "$TRAVIS_RUST_VERSION" == "nightly" ]]; then cargo clippy --all-targets --all-features -- -D warnings; fi
   - cargo test --verbose
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ cache:
   directories:
     - /home/travis/.cargo
 before_script:
-  - if [ "$TRAVIS_RUST_VERSION" != "beta" ]; then rustup component add clippy-preview; fi
+  - if [[ "$TRAVIS_RUST_VERSION" == "stable" || "$TRAVIS_RUST_VERSION" == "nightly" ]]; then rustup component add clippy-preview; fi
 script:
-  - if [ "$TRAVIS_RUST_VERSION" != "beta" ]; then cargo clippy --all-targets --all-features -- -D warnings; fi
+  - if [[ "$TRAVIS_RUST_VERSION" == "stable" || "$TRAVIS_RUST_VERSION" == "nightly" ]]; then cargo clippy --all-targets --all-features -- -D warnings; fi
   - cargo test --verbose
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ cache:
   directories:
     - /home/travis/.cargo
 before_script:
-  - if [[ "$TRAVIS_RUST_VERSION" == "stable" || "$TRAVIS_RUST_VERSION" == "nightly" ]]; then rustup component add clippy-preview; fi
+  - if [ "$TRAVIS_RUST_VERSION" != "beta" ]; then rustup component add clippy-preview; fi
 script:
-  - if [[ "$TRAVIS_RUST_VERSION" == "stable" || "$TRAVIS_RUST_VERSION" == "nightly" ]]; then cargo clippy --all-targets --all-features -- -D warnings; fi
+  - if [ "$TRAVIS_RUST_VERSION" != "beta" ]; then cargo clippy --all-targets --all-features -- -D warnings; fi
   - cargo test --verbose
 matrix:
   allow_failures:


### PR DESCRIPTION
Fixes #25: Do not run clippy on beta toolchain

As observed in #24, we should only invoke Clippy for the `Stable` and `Nightly` build channels on Travis.

Unfortunately, versions of Clippy vary across channels. With `Beta` deriving from `Nightly` (_which is allowed to fail_), we'll just disable Clippy for `Beta` to still preview new releases.