### PR TITLE
bug: Update Travis build criteria for branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: rust
+branches:
+  only:
+    - master
 os:
   - linux
   - windows


### PR DESCRIPTION
Fixes #29: Update Travis build criteria for branches

This PR, in combination with enabling both of the following:

1. Build branch updates
2. Build pull request updates

will allow all pull requests to be built using Travis in addition to only the master branch. This is key as owners/contributors of the repo will not fork it for development, meaning their branches will be built
pre-maturely before opening a pull request.