### PR TITLE
Warn the user if they are not providing an auth token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,11 @@ extern crate reqwest;
 extern crate serde_derive;
 extern crate serde_json;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Utc, Local};
 use reqwest::header::{qitem, Accept, Authorization, Bearer, Link, RelationType, UserAgent};
 use serde_derive::Deserialize;
 use std::{error, fmt, mem};
+use std::time::{UNIX_EPOCH, Duration};
 
 #[derive(Debug)]
 pub struct Config {
@@ -116,6 +117,7 @@ pub fn collect_stars(config: Config) -> Result<(), Box<dyn error::Error>> {
     while next_link.is_some() {
         if let Some(link) = next_link {
             let mut res = client.get(&link).send()?;
+
             next_link = extract_link_next(res.headers());
 
             let mut s: Vec<Star> = res.json()?;
@@ -123,15 +125,45 @@ pub fn collect_stars(config: Config) -> Result<(), Box<dyn error::Error>> {
         }
     }
 
-    // for star in stars.iter() {
-    //     println!("{}", star);
-    // }
+    for star in stars.iter() {
+        println!("{}", star);
+    }
     println!("Collected {} stars", stars.len());
 
     Ok(())
 }
 
 fn extract_link_next(headers: &reqwest::header::Headers) -> Option<String> {
+    let total_rate_limit = "X-RateLimit-Limit";
+    let rate_limit_remaining = "X-RateLimit-Remaining";
+    let rate_limit_reset_time = "X-RateLimit-Reset";   
+    
+    let mut remaining: i32 = 0; 
+    let mut total: i32 = 0;
+
+    for header in headers.iter() {
+       if header.name() == total_rate_limit {
+           total = header.value_string().parse::<i32>().unwrap();
+       }
+       if header.name() == rate_limit_remaining {
+           remaining = header.value_string().parse::<i32>().unwrap();
+       }
+       if header.name() == rate_limit_reset_time {
+            let reset_time = header.value_string();
+            let timestamp = reset_time.parse::<u64>().unwrap();
+
+            // Creates a new SystemTime from the specified number of whole seconds
+            let d = UNIX_EPOCH + Duration::from_secs(timestamp);
+            
+            // Create DateTime from SystemTime
+            let datetime = DateTime::<Local>::from(d);
+
+            // Formats the combined date and time with the specified format string.
+            let timestamp_str = datetime.format("%Y-%m-%d %I:%M").to_string();
+            println!{"You have {} out of {} requests remaining. Your request limit will reset at {}", remaining, total, timestamp_str};
+        }
+    }
+   
     let link_headers = headers.get::<Link>();
 
     match link_headers {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub fn collect_stars(config: Config) -> Result<(), Box<dyn error::Error>> {
     if let Some(ref token) = config.token {
         builder.set_authorization_token(token.to_owned());
     }
+    else {
+        println!("Authentication Warning: You have not provided an auth token and are liimted to 60 requests per hour. Provide an auth token by running the program with '--token <auth-token>' for 5000 requests per hour.");
+    }
 
     let client = builder.build()?;
 
@@ -120,9 +123,9 @@ pub fn collect_stars(config: Config) -> Result<(), Box<dyn error::Error>> {
         }
     }
 
-    for star in stars.iter() {
-        println!("{}", star);
-    }
+    // for star in stars.iter() {
+    //     println!("{}", star);
+    // }
     println!("Collected {} stars", stars.len());
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub fn collect_stars(config: Config) -> Result<(), Box<dyn error::Error>> {
         builder.set_authorization_token(token.to_owned());
     }
     else {
-        println!("Authentication Warning: You have not provided an auth token and are liimted to 60 requests per hour. Provide an auth token by running the program with '--token <auth-token>' for 5000 requests per hour.");
+        println!("Authentication Warning: This is an unauthenticated request with a limit of 60 requests per hour. Re-run this program using an auth token by adding `--token <auth-token>` for an increased quota of 5000 requests per hour.")
     }
 
     let client = builder.build()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub fn collect_stars(config: Config) -> Result<(), Box<dyn error::Error>> {
                 StatusCode::Forbidden => {
                     return Err(format!("Uh-oh! You have {} out of {} requests remaining. Your request limit will reset at {}", remaining, total, timestamp_str).into());
                 },
-                s => (),
+                _ => (),
             }
 
             next_link = extract_link_next(res.headers());


### PR DESCRIPTION
Fixes issue #13 to warn user if they are not providing an auth token. 
I know the code can probably be written more efficiently and be modularized- please share your thoughts and suggestions/ provide direction. 

Some side notes: 
1. Is there a way to retrieve the next page without making an entirely new api request? Given that each page counts for one 'request', if someone has a lot of stars (like @SeanPrashad) running the program more than once in the same hour (without auth token) uses up all the requests. The current behavior fails to display **any** stars on the second program call.   
For eg: username `seanprashad` has 909 stars, and it's 30 per page. That's 31 requests for one program call. When I run the program a second time with same username, it fails to display any of the stars, even though it can technically make 29 more requests. @0xazure can you please point out why/where this behavior occurs in the code, and let me know if I should fix it/open another issue for this? Not sure if the original code had this behavior, or if my new code introduced this 'bug'. I can try to do some more testing later.
2. Not sure if this is relevant, but should we look into [this](https://developer.github.com/v3/#conditional-requests)  for cacheing results to avoid wasting rate limit counts? Not sure how it would work between each program run, but let me know if you think it's something worth exploring and testing out. 