### PR TITLE
Grabbing main repo language and displaying it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,12 +90,12 @@ impl fmt::Display for Repository {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[{}]({})", self.full_name, self.html_url)?;
 
-        if let Some(ref description) = self.description {
-            write!(f, " - {}", description)?;
+        if let Some(ref language) = self.language {
+            write!(f, " ({})", language)?;
         }
 
-        if let Some(ref language) = self.language {
-            write!(f, "Main Language: {}", language)?;
+        if let Some(ref description) = self.description {
+            write!(f, " - {}", description)?;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ struct Repository {
     full_name: String,
     description: Option<String>,
     stargazers_count: i32,
+    language: Option<String>, 
 }
 
 impl fmt::Display for Repository {
@@ -91,6 +92,10 @@ impl fmt::Display for Repository {
 
         if let Some(ref description) = self.description {
             write!(f, " - {}", description)?;
+        }
+
+        if let Some(ref language) = self.language {
+            write!(f, "Main Language: {}", language)?;
         }
 
         Ok(())


### PR DESCRIPTION
Closes #40. Adds the main repo language to the Repo struct and implements in a display. 