### PR TITLE
Print tool versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,13 @@ cache:
     - /home/travis/.cargo
 before_script:
   - if [[ "$TRAVIS_RUST_VERSION" == "stable" || "$TRAVIS_RUST_VERSION" == "nightly" ]]; then rustup component add clippy-preview; fi
+  - rustup component add rustfmt
 script:
   - if [[ "$TRAVIS_RUST_VERSION" == "stable" || "$TRAVIS_RUST_VERSION" == "nightly" ]]; then cargo clippy --all-targets --all-features -- -D warnings; fi
+  - cargo fmt --all --write-mode diff
+  - cargo build
   - cargo test --verbose
+
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,9 @@ matrix:
       rust: stable
       before_script:
         - rustup component add clippy-preview
+        - cargo clippy --version
         - rustup component add rustfmt
+        - rustfmt --version
       script:
         - cargo clippy --all-targets --all-features -- -D warnings
         - cargo fmt --all -- --check
@@ -59,7 +61,9 @@ matrix:
       rust: nightly
       before_script:
         - rustup component add clippy-preview
+        - cargo clippy --version
         - rustup component add rustfmt
+        - rustfmt --version
       script:
         - cargo clippy --all-targets --all-features -- -D warnings
         - cargo fmt --all -- --check
@@ -72,7 +76,9 @@ matrix:
       rust: stable
       before_script:
         - rustup component add clippy-preview
+        - cargo clippy --version
         - rustup component add rustfmt
+        - rustfmt --version
       script:
         - cargo clippy --all-targets --all-features -- -D warnings
         - cargo fmt --all -- --check
@@ -94,7 +100,9 @@ matrix:
       rust: nightly
       before_script:
         - rustup component add clippy-preview
+        - cargo clippy --version
         - rustup component add rustfmt
+        - rustfmt --version
       script:
         - cargo clippy --all-targets --all-features -- -D warnings
         - cargo fmt --all -- --check


### PR DESCRIPTION
Fixes issue #32 .

Note: this branches off of my iss-21 PR #39 branch. Not sure if this was the correct way to do it? 
#39 has not been merged yet, and I wanted to include the version check for the tool I added in that PR, that's why I did it this way. 

Also question: @SeanPrashad added [`clippy-preview`](https://github.com/0xazure/supernova/blob/66f5bc50aa6bfe8c359e684279e3c889039b8d0e/.travis.yml#L41). Wondering why not just `rustup component add clippy`, and if the rustfmt should also be `rustfmt-preview`? 
Couldn't find much about this online in the little digging I did... 